### PR TITLE
Chore: add React 17 to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	},
 	"peerDependencies": {
 		"prop-types": "^15.0.0",
-		"react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+		"react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.11.1",


### PR DESCRIPTION
React 17 was released on 2020-10-20 ([announcement](https://reactjs.org/blog/2020/10/20/react-v17.html)); add it to `peerDependencies` to avoid NPM warnings.